### PR TITLE
Provided a knob to specify max model length for the orpheus-tts model.

### DIFF
--- a/orpheus_tts_pypi/orpheus_tts/engine_class.py
+++ b/orpheus_tts_pypi/orpheus_tts/engine_class.py
@@ -7,11 +7,12 @@ import queue
 from .decoder import tokens_decoder_sync
 
 class OrpheusModel:
-    def __init__(self, model_name, dtype=torch.bfloat16):
+    def __init__(self, model_name, dtype=torch.bfloat16, max_model_len=52000):
         self.model_name = self._map_model_params(model_name)
         self.dtype = dtype
+        self.max_model_len = max_model_len
         self.engine = self._setup_engine()
-        self.available_voices = ["zoe", "zac","jess", "leo", "mia", "julia", "leah"]
+        self.available_voices = ["tara", "zoe", "zac","jess", "leo", "mia", "julia", "leah"]
         self.tokeniser = AutoTokenizer.from_pretrained(model_name)
 
     
@@ -42,6 +43,7 @@ class OrpheusModel:
         engine_args = AsyncEngineArgs(
             model=self.model_name,
             dtype=self.dtype,
+            max_model_len = self.max_model_len
         )
         return AsyncLLMEngine.from_engine_args(engine_args)
     


### PR DESCRIPTION
**Why This PR ?**
By default, the integrated vLLM engine throws error (as shown below) for `orpheus-tts` model (any version) when run over an average grade GPUs (e.g. T4).

This PR provides a knob which can be tweaked according to the requirement to make `orpheus-tts` model work with average grade GPUs (e.g. T4) as well.

**Error**
ValueError: The model's max seq len (131072) is larger than the maximum number of tokens that can be stored in KV cache (52400). Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine.