### PR TITLE
Set the lang on the no GPU example

### DIFF
--- a/additional_inference_options/no_gpu/README.md
+++ b/additional_inference_options/no_gpu/README.md
@@ -23,7 +23,7 @@ You can stream audio without a GPU by using `orpheus-cpp`, which is a llama.cpp-
    from orpheus_cpp import OrpheusCpp
    import numpy as np
 
-   orpheus = OrpheusCpp(verbose=False)
+   orpheus = OrpheusCpp(verbose=False, lang="en")
 
    text = "I really hope the project deadline doesn't get moved up again."
    buffer = []


### PR DESCRIPTION
By default the language is set to spanish as you can see here: https://github.com/freddyaboulton/orpheus-cpp/blob/ed126bea531ea9d53ef7564b00e8bc23f8f9aebe/src/orpheus_cpp/model.py#L59

This default setting can lead to amusing experiences during testing, but it doesn't fully showcase Orpheus's capabilities.