### PR TITLE
Fix installation steps in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Baseten is our [preferred inference partner](https://www.baseten.co/blog/canopy-
    ```
 2. Navigate and install packages
    ```bash
-   cd Orpheus-TTS && pip install orpheus-speech # uses vllm under the hood for fast inference
+   cd Orpheus-TTS && pip install -e orpheus_tts_pypi # uses vllm under the hood for fast inference
    ```
    vllm pushed a slightly buggy version on March 18th so some bugs are being resolved by reverting to `pip install vllm==0.7.3` after `pip install orpheus-speech`
 4. Run the example below:


### PR DESCRIPTION
Steps "clone the repo" and "install package from pip" are contradictory: if you install the pip package, you don't need the repo.
However, the current release of the pip package doesn't work with the example from README sice OrpheusModel lacks **engine_kwargs in that release. So it makes more sense to install the package from the repo.